### PR TITLE
Configurable vcpkg path

### DIFF
--- a/Bootstrap.ps1
+++ b/Bootstrap.ps1
@@ -1,11 +1,23 @@
-git clone https://github.com/microsoft/vcpkg.git
+param (
+	[String]
+	$VcpkgPath = "./vcpkg"
+)
+
+$setupVcpkg = !(Test-Path -Path $VcpkgPath)
+$vcpkgURL = "https://github.com/microsoft/vcpkg.git"
 
 if($isWindows) {
-	./vcpkg/bootstrap-vcpkg.bat
-	./vcpkg/vcpkg install catch2:x64-windows
-	./vcpkg/vcpkg install rapidcheck:x64-windows
+	if ($setupVcpkg) {
+		git clone $vcpkgURL $VcpkgPath
+		& $VcpkgPath/bootstrap-vcpkg.bat
+	}
+	& $VcpkgPath/vcpkg install catch2:x64-windows
+	& $VcpkgPath/vcpkg install rapidcheck:x64-windows
 } elseif($isLinux) {
-	sh ./vcpkg/bootstrap-vcpkg.sh
-	./vcpkg/vcpkg install catch2:x64-linux
-	./vcpkg/vcpkg install rapidcheck:x64-linux
+	if ($setupVcpkg) {
+		git clone $vcpkgURL $VcpkgPath
+		sh $VcpkgPath/bootstrap-vcpkg.sh
+	}
+	& $VcpkgPath/vcpkg install catch2:x64-linux
+	& $VcpkgPath/vcpkg install rapidcheck:x64-linux
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,17 +27,22 @@ jobs:
     pool:
       vmImage: $(imageName)
     displayName: Build (Native)
+    variables:
+      vcpkgPath: $(Build.Repository.LocalPath)/vcpkg
     steps:
     - task: Cache@2
       inputs:
         key: 'vcpkg | "$(Agent.OS)"'
-        path: $(Build.Repository.LocalPath)/vcpkg
-        cacheHitVar: DOCKER_CACHE_RESTORED
+        path: $(vcpkgPath)
+        cacheHitVar: VCPKG_CACHE_RESTORED
       displayName: Caching vcpkg
-    - pwsh: ./Bootstrap.ps1
+    - pwsh: ./Bootstrap.ps1 -VcpkgPath $(vcpkgPath)
       displayName: Boostrap
-      condition: and(not(canceled()), or(failed(), ne(variables.DOCKER_CACHE_RESTORED, 'true')))
-    - pwsh: ./Build.ps1 -SourceDirectory $(Build.SourcesDirectory) -BuildDirectory $(Build.BinariesDirectory)
+      condition: and(not(canceled()), or(failed(), ne(variables.VCPKG_CACHE_RESTORED, 'true')))
+    - pwsh: |
+        ./Build.ps1 -SourceDirectory $(Build.SourcesDirectory) `
+                    -BuildDirectory $(Build.BinariesDirectory) `
+                    -ToolChainFile $(vcpkgPath)/scripts/buildsystems/vcpkg.cmake
       displayName: Build
     - pwsh: cd $(Build.BinariesDirectory) && ctest
       displayName: Test
@@ -69,7 +74,10 @@ jobs:
       displayName: Push image
     - pwsh: docker logout
       displayName: Logout from Docker Hub
-    - pwsh: ./BuildContainerized.ps1 -ImageName $(dockerImageName) -HostSourceDirectory $(Build.SourcesDirectory) -HostBuildDirectory $(Build.BinariesDirectory)
+    - pwsh: |
+        ./BuildContainerized.ps1 -ImageName $(dockerImageName) `
+                                 -HostSourceDirectory $(Build.SourcesDirectory) `
+                                 -HostBuildDirectory $(Build.BinariesDirectory)
       displayName: Build
     - pwsh: cd $(Build.BinariesDirectory) && ctest
       displayName: Test


### PR DESCRIPTION
Make the path to vcpkg configurable. Allows to use local intallations and the existing installation on azure devops hosted agents.