### PR TITLE
Vcpkg manifest mode

### DIFF
--- a/Bootstrap.ps1
+++ b/Bootstrap.ps1
@@ -11,13 +11,9 @@ if($isWindows) {
 		git clone $vcpkgURL $VcpkgPath
 		& $VcpkgPath/bootstrap-vcpkg.bat
 	}
-	& $VcpkgPath/vcpkg install catch2:x64-windows
-	& $VcpkgPath/vcpkg install rapidcheck:x64-windows
 } elseif($isLinux) {
 	if ($setupVcpkg) {
 		git clone $vcpkgURL $VcpkgPath
 		sh $VcpkgPath/bootstrap-vcpkg.sh
 	}
-	& $VcpkgPath/vcpkg install catch2:x64-linux
-	& $VcpkgPath/vcpkg install rapidcheck:x64-linux
 }

--- a/Build.ps1
+++ b/Build.ps1
@@ -15,7 +15,7 @@ param(
 
 
 if($isWindows) {
-	$AdditionalConfigureArguments = "-G", "Visual Studio 16 2019",  "-A", "x64"
+	$AdditionalConfigureArguments = "-G", "Visual Studio 17 2022",  "-A", "x64"
     $AdditionalBuildArguments = "--config", "$BuildType"
 } elseif($isLinux) {
     $AdditionalConfigureArguments = "-G", "Unix Makefiles"

--- a/library/test/CMakeLists.txt
+++ b/library/test/CMakeLists.txt
@@ -7,9 +7,10 @@ add_test(property_test property_test)
 find_package(Catch2 CONFIG REQUIRED)
 find_package(rapidcheck CONFIG REQUIRED)
 
-target_link_libraries(library_test PRIVATE library)
-target_link_libraries(library_test PRIVATE Catch2::Catch2)
+target_link_libraries(library_test PRIVATE library Catch2::Catch2WithMain)
 
-target_link_libraries(property_test PRIVATE library)
-target_link_libraries(property_test PRIVATE rapidcheck rapidcheck_boost rapidcheck_catch rapidcheck_gmock)
-target_link_libraries(property_test PRIVATE Catch2::Catch2)
+target_link_libraries(property_test PRIVATE 
+	library 
+	Catch2::Catch2WithMain 
+	rapidcheck rapidcheck_boost rapidcheck_catch rapidcheck_gmock
+)

--- a/library/test/library_test.cpp
+++ b/library/test/library_test.cpp
@@ -1,6 +1,4 @@
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include <catch.hpp>
-
+#include <catch2/catch_test_macros.hpp>
 #include <library.h>
 
 TEST_CASE("One plus one", "[add]")

--- a/library/test/property_test.cpp
+++ b/library/test/property_test.cpp
@@ -1,8 +1,6 @@
 #include <rapidcheck.h>
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include <catch.hpp>
-
-#include<library.h>
+#include <catch2/catch_test_macros.hpp>
+#include <library.h>
 
 TEST_CASE("add property check", "[add]")
 {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "cpp-project-template",
+  "version": "1.0.0",
+  "dependencies": [
+    "catch2",
+    "rapidcheck"
+  ]
+}


### PR DESCRIPTION
Use vcpkg manifest mode instead of installing requirements in a boostrap script.